### PR TITLE
Enable purple scrip collectable turnins

### DIFF
--- a/CraftersScrips.lua
+++ b/CraftersScrips.lua
@@ -470,6 +470,9 @@ function TurnIn()
             yield("/interact")
             yield("/wait 1")
         else
+			if ScripColor == "Purple" then
+				yield("/callback CollectablesShop true 12 1")
+			end
             yield("/callback CollectablesShop true 15 0")
             yield("/wait 1")
         end


### PR DESCRIPTION
If crafting for Purple scripts, select the the second item before mashing submit