### PR TITLE
Some changes I made to the script to maybe help out casters + fate priority, and a few other smaller settings.

### DIFF
--- a/Fate Farming/Fate Farming.lua
+++ b/Fate Farming/Fate Farming.lua
@@ -2398,7 +2398,7 @@ function Ready()
             else
                 LogInfo("[FATE] Waiting for fate rewards")
             end
-        elseif (not HasTarget() or GetTargetName() ~= "aetheryte" or GetDistanceToTarget()) and DownTimeWaitAtNearestAetheryte > 20 then
+        elseif (not HasTarget() or GetTargetName() ~= "aetheryte" or GetDistanceToTarget() > 20) and DownTimeWaitAtNearestAetheryte then
             State = CharacterState.flyBackToAetheryte
             LogInfo("[FATE] State Change: FlyBackToAetheryte")
         else

--- a/Fate Farming/Fate Farming.lua
+++ b/Fate Farming/Fate Farming.lua
@@ -23,8 +23,7 @@ State Machine Diagram: https://github.com/pot0to/pot0to-SND-Scripts/blob/main/Fa
                     for the rotation plugin.
                 Small adjustment to wait time after choosing nextFate, results
                     in landing further from center of fates upon approach.
-                Logic change for nudging closer to enemies.
-                New extra check in movement to prevent cast cancelling.
+                New extra checks in movement to prevent cast cancelling.
                 May have messed something up when pushed out of the fate.
                 Fixed typo with "should it to Turn" -> "should it do Turn"
         

--- a/Fate Farming/Fate Farming.lua
+++ b/Fate Farming/Fate Farming.lua
@@ -26,6 +26,7 @@ State Machine Diagram: https://github.com/pot0to/pot0to-SND-Scripts/blob/main/Fa
                 Logic change for nudging closer to enemies.
                 New extra check in movement to prevent cast cancelling.
                 May have messed something up when pushed out of the fate.
+                Fixed typo with "should it to Turn" -> "should it do Turn"
         
     -> 2.21.8   Added logic to change back to original class upon natural ending
                     of script for companion mode
@@ -90,12 +91,12 @@ This Plugins are Optional and not needed unless you have it enabled in the setti
 ]]
 
 --Pre Fate Settings
-Food                                = "Boiled Egg"  --Leave "" Blank if you don't want to use any food. If its HQ include <hq> next to the name "Baked Eggplant <hq>"
+Food                                = ""            --Leave "" Blank if you don't want to use any food. If its HQ include <hq> next to the name "Baked Eggplant <hq>"
 Potion                              = ""            --Leave "" Blank if you don't want to use any potions.
 ShouldSummonChocobo                 = true          --Summon chocobo?
     ResummonChocoboTimeLeft         = 3 * 60        --Resummons chocobo if there's less than this many seconds left on the timer, so it doesn't disappear on you in the middle of a fate.
     ChocoboStance                   = "Healer"      --Options: Follow/Free/Defender/Healer/Attacker
-    ShouldAutoBuyGysahlGreens       = false          --Automatically buys a 99 stack of Gysahl Greens from the Limsa gil vendor if you're out
+    ShouldAutoBuyGysahlGreens       = true          --Automatically buys a 99 stack of Gysahl Greens from the Limsa gil vendor if you're out
 MountToUse                          = "mount roulette"       --The mount you'd like to use when flying between fates
 FatePriority                        = {"DistanceTeleport", "Progress", "DistanceTeleport", "Bonus", "TimeLeft", "Distance"}
 
@@ -109,7 +110,7 @@ CompletionToJoinBossFate            = 0             --If the boss fate has less 
 JoinCollectionsFates                = true          --Set to false if you never want to do collections fates
 BonusFatesOnly                      = false         --If true, will only do bonus fates and ignore everything else
 
-MeleeDist                           = 2.5            --Distance for melee. Melee attacks (auto attacks) max distance is 2.59y, 2.60 is "target out of range"
+MeleeDist                           = 2.5           --Distance for melee. Melee attacks (auto attacks) max distance is 2.59y, 2.60 is "target out of range"
 RangedDist                          = 20            --Distance for ranged. Ranged attacks and spells max distance to be usable is 25.49y, 25.5 is "target out of range"=
 
 RotationPlugin                      = "RSR"         --Options: RSR/BMR/VBM/Wrath/None
@@ -120,7 +121,7 @@ RotationPlugin                      = "RSR"         --Options: RSR/BMR/VBM/Wrath
     RotationAoePreset               = ""            --Preset with AOE + Buff strategies.
     RotationHoldBuffPreset          = ""            --Preset to hold 2min burst when progress gets to seleted %
     PercentageToHoldBuff            = 65            --Ideally you'll want to make full use of your buffs, higher than 70% will still waste a few seconds if progress is too fast.
-DodgingPlugin                       = "VBM"         --Options: BMR/VBM/None. If your RotationPlugin is BMR/VBM, then this will be overriden
+DodgingPlugin                       = "BMR"         --Options: BMR/VBM/None. If your RotationPlugin is BMR/VBM, then this will be overriden
 
 IgnoreForlorns                      = false
     IgnoreBigForlornOnly            = false
@@ -133,19 +134,19 @@ DownTimeWaitAtNearestAetheryte      = false         --When waiting for fates to 
 EnableChangeInstance                = true          --should it Change Instance when there is no Fate (only works on DT fates)
     WaitIfBonusBuff                 = true          --Don't change instances if you have the Twist of Fate bonus buff
     NumberOfInstances               = 2
-ShouldExchangeBicolorGemstones      = false         --Should it exchange Bicolor Gemstone Vouchers?
+ShouldExchangeBicolorGemstones      = true         --Should it exchange Bicolor Gemstone Vouchers?
     ItemToPurchase                  = "Turali Bicolor Gemstone Voucher"        -- Old Sharlayan for "Bicolor Gemstone Voucher" and Solution Nine for "Turali Bicolor Gemstone Voucher"
-SelfRepair                          = true         --if false, will go to Limsa mender
+SelfRepair                          = false         --if false, will go to Limsa mender
     RepairAmount                    = 20            --the amount it needs to drop before Repairing (set it to 0 if you don't want it to repair)
     ShouldAutoBuyDarkMatter         = true          --Automatically buys a 99 stack of Grade 8 Dark Matter from the Limsa gil vendor if you're out
 ShouldExtractMateria                = true          --should it Extract Materia
-Retainers                           = false          --should it do Retainers
+Retainers                           = true          --should it do Retainers
 ShouldGrandCompanyTurnIn            = false         --should it do Turn ins at the GC (requires Deliveroo)
     InventorySlotsLeft              = 5             --how much inventory space before turning in
 
 Echo                                = "All"         --Options: All/Gems/None
 
-CompanionScriptMode                 = true         --Set to true if you are using the fate script with a companion script (such as the Atma Farmer)
+CompanionScriptMode                 = false         --Set to true if you are using the fate script with a companion script (such as the Atma Farmer)
 
 --#endregion Settings
 

--- a/Fate Farming/Fate Farming.lua
+++ b/Fate Farming/Fate Farming.lua
@@ -2,11 +2,30 @@
 
 ********************************************************************************
 *                                Fate Farming                                  *
-*                               Version 2.21.8                                 *
+*                               Version 2.21.9                                 *
 ********************************************************************************
 
 Created by: pot0to (https://ko-fi.com/pot0to)
 State Machine Diagram: https://github.com/pot0to/pot0to-SND-Scripts/blob/main/FateFarmingStateMachine.drawio.png
+
+    -> 2.21.9   By Allison
+                Added priority for checking distance to FATE accounting for a
+                    possible lower distance if you teleported.
+                Added FatePriority Setting. Default works the same as before 
+                    but with new check from above. 
+                    Progress -> Bonus -> Time Left -> Distance
+                Added setting for if you should wait at the Aetheryte when no 
+                    FATE is found. If you disable, you wait where the FATE 
+                    finished.
+                Added MinWait setting because sometimes 3 seconds felt to long.
+                Changed name of WaitUpTo to match MinWait.
+                Added check to disable targeting with VBM if you are using RSR
+                    for the rotation plugin.
+                Small adjustment to wait time after choosing nextFate, results
+                    in landing further from center of fates upon approach.
+                Logic change for nudging closer to enemies.
+                New extra check in movement to prevent cast cancelling.
+                May have messed something up when pushed out of the fate.
         
     -> 2.21.8   Added logic to change back to original class upon natural ending
                     of script for companion mode
@@ -71,13 +90,14 @@ This Plugins are Optional and not needed unless you have it enabled in the setti
 ]]
 
 --Pre Fate Settings
-Food                                = ""            --Leave "" Blank if you don't want to use any food. If its HQ include <hq> next to the name "Baked Eggplant <hq>"
+Food                                = "Boiled Egg"  --Leave "" Blank if you don't want to use any food. If its HQ include <hq> next to the name "Baked Eggplant <hq>"
 Potion                              = ""            --Leave "" Blank if you don't want to use any potions.
 ShouldSummonChocobo                 = true          --Summon chocobo?
     ResummonChocoboTimeLeft         = 3 * 60        --Resummons chocobo if there's less than this many seconds left on the timer, so it doesn't disappear on you in the middle of a fate.
     ChocoboStance                   = "Healer"      --Options: Follow/Free/Defender/Healer/Attacker
-    ShouldAutoBuyGysahlGreens       = true          --Automatically buys a 99 stack of Gysahl Greens from the Limsa gil vendor if you're out
+    ShouldAutoBuyGysahlGreens       = false          --Automatically buys a 99 stack of Gysahl Greens from the Limsa gil vendor if you're out
 MountToUse                          = "mount roulette"       --The mount you'd like to use when flying between fates
+FatePriority                        = {"DistanceTeleport", "Progress", "DistanceTeleport", "Bonus", "TimeLeft", "Distance"}
 
 --Fate Combat Settings
 CompletionToIgnoreFate              = 80            --If the fate has more than this much progress already, skip it
@@ -89,7 +109,7 @@ CompletionToJoinBossFate            = 0             --If the boss fate has less 
 JoinCollectionsFates                = true          --Set to false if you never want to do collections fates
 BonusFatesOnly                      = false         --If true, will only do bonus fates and ignore everything else
 
-MeleeDist                           = 2.5           --Distance for melee. Melee attacks (auto attacks) max distance is 2.59y, 2.60 is "target out of range"
+MeleeDist                           = 2.5            --Distance for melee. Melee attacks (auto attacks) max distance is 2.59y, 2.60 is "target out of range"
 RangedDist                          = 20            --Distance for ranged. Ranged attacks and spells max distance to be usable is 25.49y, 25.5 is "target out of range"=
 
 RotationPlugin                      = "RSR"         --Options: RSR/BMR/VBM/Wrath/None
@@ -100,30 +120,32 @@ RotationPlugin                      = "RSR"         --Options: RSR/BMR/VBM/Wrath
     RotationAoePreset               = ""            --Preset with AOE + Buff strategies.
     RotationHoldBuffPreset          = ""            --Preset to hold 2min burst when progress gets to seleted %
     PercentageToHoldBuff            = 65            --Ideally you'll want to make full use of your buffs, higher than 70% will still waste a few seconds if progress is too fast.
-DodgingPlugin                       = "BMR"         --Options: BMR/VBM/None. If your RotationPlugin is BMR/VBM, then this will be overriden
+DodgingPlugin                       = "VBM"         --Options: BMR/VBM/None. If your RotationPlugin is BMR/VBM, then this will be overriden
 
 IgnoreForlorns                      = false
     IgnoreBigForlornOnly            = false
 
 --Post Fate Settings
-WaitUpTo                            = 10            --Max number of seconds it should wait until mounting up for next fate.
-                                                        --Actual wait time will be a randomly generated number between 3s and this value
+MinWait                             = 3             --Min number of seconds it should wait until mounting up for next fate.
+MaxWait                             = 6             --Max number of seconds it should wait until mounting up for next fate.
+                                                        --Actual wait time will be a randomly generated number between MinWait and MaxWait.
+DownTimeWaitAtNearestAetheryte      = false         --When waiting for fates to pop, should you fly to the nearest Aetheryte and wait there?
 EnableChangeInstance                = true          --should it Change Instance when there is no Fate (only works on DT fates)
     WaitIfBonusBuff                 = true          --Don't change instances if you have the Twist of Fate bonus buff
     NumberOfInstances               = 2
-ShouldExchangeBicolorGemstones      = true          --Should it exchange Bicolor Gemstone Vouchers?
+ShouldExchangeBicolorGemstones      = false         --Should it exchange Bicolor Gemstone Vouchers?
     ItemToPurchase                  = "Turali Bicolor Gemstone Voucher"        -- Old Sharlayan for "Bicolor Gemstone Voucher" and Solution Nine for "Turali Bicolor Gemstone Voucher"
-SelfRepair                          = false         --if false, will go to Limsa mender
+SelfRepair                          = true         --if false, will go to Limsa mender
     RepairAmount                    = 20            --the amount it needs to drop before Repairing (set it to 0 if you don't want it to repair)
     ShouldAutoBuyDarkMatter         = true          --Automatically buys a 99 stack of Grade 8 Dark Matter from the Limsa gil vendor if you're out
 ShouldExtractMateria                = true          --should it Extract Materia
-Retainers                           = true          --should it do Retainers
-ShouldGrandCompanyTurnIn            = false         --should it to Turn ins at the GC (requires Deliveroo)
+Retainers                           = false          --should it do Retainers
+ShouldGrandCompanyTurnIn            = false         --should it do Turn ins at the GC (requires Deliveroo)
     InventorySlotsLeft              = 5             --how much inventory space before turning in
 
 Echo                                = "All"         --Options: All/Gems/None
 
-CompanionScriptMode                 = false         --Set to true if you are using the fate script with a companion script (such as the Atma Farmer)
+CompanionScriptMode                 = true         --Set to true if you are using the fate script with a companion script (such as the Atma Farmer)
 
 --#endregion Settings
 
@@ -1023,9 +1045,11 @@ function SelectNextZone()
 end
 
 --[[
-    Given two fates, picks the better one based on priority progress -> is bonus -> time left -> distance
+    Selects the better fate based on the priority order defined in FatePriority.
+    Default Priority order is "Progress" -> "DistanceTeleport" -> "Bonus" -> "TimeLeft" -> "Distance"
 ]]
 function SelectNextFateHelper(tempFate, nextFate)
+    --Check if WaitForBonusIfBonusBuff is true, and have eithe buff, then set BonusFatesOnlyTemp to true
     if BonusFatesOnly then
         if not tempFate.isBonusFate and nextFate ~= nil and nextFate.isBonusFate then
             return nextFate
@@ -1038,59 +1062,48 @@ function SelectNextFateHelper(tempFate, nextFate)
     end
 
     if tempFate.timeLeft < MinTimeLeftToIgnoreFate or tempFate.progress > CompletionToIgnoreFate then
+        LogInfo("[FATE] Ignoring fate #"..tempFate.fateId.." due to insufficient time or high completion.")
         return nextFate
-    else
-        if nextFate == nil then
-                LogInfo("[FATE] Selecting #"..tempFate.fateId.." because no other options so far.")
-                return tempFate
-        -- elseif nextFate.startTime == 0 and tempFate.startTime > 0 then -- nextFate is an unopened npc fate
-        --     LogInfo("[FATE] Selecting #"..tempFate.fateId.." because other fate #"..nextFate.fateId.." is an unopened npc fate.")
-        --     return tempFate
-        -- elseif tempFate.startTime == 0 and nextFate.startTime > 0 then -- tempFate is an unopened npc fate
-        --     return nextFate
-        elseif nextFate.timeLeft < MinTimeLeftToIgnoreFate or nextFate.progress > CompletionToIgnoreFate then
-            return tempFate
-        else -- select based on progress
-            if tempFate.progress > nextFate.progress then
-                LogInfo("[FATE] Selecting #"..tempFate.fateId.." because other fate #"..nextFate.fateId.." has less progress.")
-                return tempFate
-            elseif tempFate.progress < nextFate.progress then
-                LogInfo("[FATE] Selecting #"..nextFate.fateId.." because other fate #"..tempFate.fateId.." has less progress.")
-                return nextFate
-            else
-                if (nextFate.isBonusFate and tempFate.isBonusFate) or (not nextFate.isBonusFate and not tempFate.isBonusFate) then
-                    if tempFate.timeLeft < nextFate.timeLeft then -- select based on time left
-                        LogInfo("[FATE] Selecting #"..tempFate.fateId.." because other fate #"..nextFate.fateId.." has more time left.")
-                        return tempFate
-                    elseif tempFate.timeLeft > nextFate.timeLeft then
-                        LogInfo("[FATE] Selecting #"..tempFate.fateId.." because other fate #"..nextFate.fateId.." has more time left.")
-                        return nextFate
-                    else
-                        tempFatePlayerDistance = GetDistanceToPoint(tempFate.x, tempFate.y, tempFate.z)
-                        nextFatePlayerDistance = GetDistanceToPoint(nextFate.x, nextFate.y, nextFate.z)
-                        if tempFatePlayerDistance < nextFatePlayerDistance then
-                            LogInfo("[FATE] Selecting #"..tempFate.fateId.." because other fate #"..nextFate.fateId.." is farther.")
-                            return tempFate
-                        elseif tempFatePlayerDistance > nextFatePlayerDistance then
-                            LogInfo("[FATE] Selecting #"..nextFate.fateId.." because other fate #"..nextFate.fateId.." is farther.")
-                            return nextFate
-                        else
-                            if tempFate.fateId < nextFate.fateId then
-                                return tempFate
-                            else
-                                return nextFate
-                            end
-                        end
-                    end
-                elseif nextFate.isBonusFate then
-                    return nextFate
-                elseif tempFate.isBonusFate then
-                    return tempFate
-                end
-            end
+    elseif nextFate == nil then
+        LogInfo("[FATE] Selecting #"..tempFate.fateId.." because no other options so far.")
+        return tempFate
+    elseif nextFate.timeLeft < MinTimeLeftToIgnoreFate or nextFate.progress > CompletionToIgnoreFate then
+        LogInfo("[FATE] Ignoring fate #"..nextFate.fateId.." due to insufficient time or high completion.")
+        return tempFate
+    end
+
+    -- Evaluate based on priority (Loop through list return first non-equal priority)
+    for _, criteria in ipairs(FatePriority) do
+        if criteria == "Progress" then
+            LogInfo("[FATE] Comparing progress: "..tempFate.progress.." vs "..nextFate.progress)
+            if tempFate.progress > nextFate.progress then return tempFate end
+            if tempFate.progress < nextFate.progress then return nextFate end
+        elseif criteria == "Bonus" then
+            LogInfo("[FATE] Checking bonus status: "..tostring(tempFate.isBonusFate).." vs "..tostring(nextFate.isBonusFate))
+            if tempFate.isBonusFate and not nextFate.isBonusFate then return tempFate end
+            if nextFate.isBonusFate and not tempFate.isBonusFate then return nextFate end
+        elseif criteria == "TimeLeft" then
+            LogInfo("[FATE] Comparing time left: "..tempFate.timeLeft.." vs "..nextFate.timeLeft)
+            if tempFate.timeLeft > nextFate.timeLeft then return tempFate end
+            if tempFate.timeLeft < nextFate.timeLeft then return nextFate end
+        elseif criteria == "Distance" then
+            local tempDist = GetDistanceToPoint(tempFate.x, tempFate.y, tempFate.z)
+            local nextDist = GetDistanceToPoint(nextFate.x, nextFate.y, nextFate.z)
+            LogInfo("[FATE] Comparing distance: "..tempDist.." vs "..nextDist)
+            if tempDist < nextDist then return tempFate end
+            if tempDist > nextDist then return nextFate end
+        elseif criteria == "DistanceTeleport" then
+            local tempDist = GetDistanceToPointWithAetheryteTravel(tempFate.x, tempFate.y, tempFate.z)
+            local nextDist = GetDistanceToPointWithAetheryteTravel(nextFate.x, nextFate.y, nextFate.z)
+            LogInfo("[FATE] Comparing distance: "..tempDist.." vs "..nextDist)
+            if tempDist < nextDist then return tempFate end
+            if tempDist > nextDist then return nextFate end
         end
     end
-    return nextFate
+
+    -- Fallback: Select fate with the lower ID
+    LogInfo("[FATE] Selecting lower ID fate: "..tempFate.fateId.." vs "..nextFate.fateId)
+    return (tempFate.fateId < nextFate.fateId) and tempFate or nextFate
 end
 
 function BuildFateTable(fateId)
@@ -1145,7 +1158,7 @@ function SelectNextFate()
         local tempFate = BuildFateTable(fates[i])
         LogInfo("[FATE] Considering fate #"..tempFate.fateId.." "..tempFate.fateName)
         LogInfo("[FATE] Time left on fate #:"..tempFate.fateId..": "..math.floor(tempFate.timeLeft//60).."min, "..math.floor(tempFate.timeLeft%60).."s")
-        
+
         if not (tempFate.x == 0 and tempFate.z == 0) then -- sometimes game doesn't send the correct coords
             if not tempFate.isBlacklistedFate then -- check fate is not blacklisted for any reason
                 if tempFate.isBossFate then
@@ -1183,7 +1196,7 @@ function SelectNextFate()
     else
         LogInfo("[FATE] Final selected fate #"..nextFate.fateId.." "..nextFate.fateName)
     end
-    yield("/wait 1")
+    yield("/wait 0.211")
 
     return nextFate
 end
@@ -1203,6 +1216,41 @@ end
 --#endregion Fate Functions
 
 --#region Movement Functions
+
+function DistanceFromClosestAetheryteToPoint(x, y, z, teleportTimePenalty)
+    local closestAetheryte = nil
+    local closestTravelDistance = math.maxinteger
+    for _, aetheryte in ipairs(SelectedZone.aetheryteList) do
+        local distanceAetheryteToFate = DistanceBetween(aetheryte.x, y, aetheryte.z, x, y, z)
+        local comparisonDistance = distanceAetheryteToFate + teleportTimePenalty
+        LogInfo("[FATE] Distance via "..aetheryte.aetheryteName.." adjusted for tp penalty is "..tostring(comparisonDistance))
+
+        if comparisonDistance < closestTravelDistance then
+            LogInfo("[FATE] Updating closest aetheryte to "..aetheryte.aetheryteName)
+            closestTravelDistance = comparisonDistance
+            closestAetheryte = aetheryte
+        end
+    end
+
+    return closestTravelDistance
+end
+
+function GetDistanceToPointWithAetheryteTravel(x, y, z)
+    -- Get the direct flight distance (no aetheryte)
+    local directFlightDistance = GetDistanceToPoint(x, y, z)
+    LogInfo("[FATE] Direct flight distance is: " .. directFlightDistance)
+    
+    -- Get the distance to the closest aetheryte, including teleportation penalty
+    local distanceToAetheryte = DistanceFromClosestAetheryteToPoint(x, y, z, 200)
+    LogInfo("[FATE] Distance via closest Aetheryte is: " .. (distanceToAetheryte or "nil"))
+
+    -- Return the minimum distance, either via direct flight or via the closest aetheryte travel
+    if distanceToAetheryte == nil then
+        return directFlightDistance
+    else
+        return math.min(directFlightDistance, distanceToAetheryte)
+    end
+end
 
 function GetClosestAetheryte(x, y, z, teleportTimePenalty)
     local closestAetheryte = nil
@@ -1290,7 +1338,7 @@ function TeleportTo(aetheryteName)
 
     while EorzeaTimeToUnixTime(GetCurrentEorzeaTimestamp()) - LastTeleportTimeStamp < 5 do
         LogInfo("[FATE] Too soon since last teleport. Waiting...")
-        yield("/wait 5")
+        yield("/wait 5.001")
     end
 
     yield("/tp "..aetheryteName)
@@ -1514,7 +1562,6 @@ function Dismount()
         yield('/ac dismount')
     end
 end
-
 
 function MiddleOfFateDismount()
     if not IsFateActive(CurrentFate.fateId) then
@@ -1996,6 +2043,9 @@ function TurnOnCombatMods(rotationMode)
                 yield("/vbmai followcombat on")
                 -- yield("/bmrai followoutofcombat on")
                 yield("/vbmai maxdistancetarget " .. MaxDistance)
+                if RotationPlugin ~= "VBM" then
+                    yield("/vbmai ForbidActions on") --This Disables VBM AI Auto-Target
+                end
             end
             AiDodgingOn = true
         end
@@ -2028,6 +2078,9 @@ function TurnOffCombatMods()
                 yield("/vbmai followtarget off")
                 yield("/vbmai followcombat off")
                 yield("/vbmai followoutofcombat off")
+                if RotationPlugin ~= "VBM" then
+                    yield("/vbmai ForbidActions off") --This Enables VBM AI Auto-Target
+                end
             end
             AiDodgingOn = false
         end
@@ -2048,13 +2101,14 @@ function HandleUnexpectedCombat()
         TurnOffCombatMods()
         State = CharacterState.ready
         LogInfo("[FATE] State Change: Ready")
-        local randomWait = (math.floor(math.random()*WaitUpTo * 1000)/1000) + 3 -- truncated to 3 decimal places
+        local randomWait = (math.floor(math.random()*MaxWait * 1000)/1000) + MinWait -- truncated to 3 decimal places
         yield("/wait "..randomWait)
         return
     end
 
     if GetCharacterCondition(CharacterCondition.mounted) then
         if not (PathfindInProgress() or PathIsRunning()) then
+            yield("/echo Unexpected Combat Move 1")
             PathfindAndMoveTo(GetPlayerRawXPos(), GetPlayerRawYPos() + 10, GetPlayerRawZPos(), true)
         end
         yield("/wait 10")
@@ -2070,6 +2124,7 @@ function HandleUnexpectedCombat()
     if HasTarget() then
         if GetDistanceToTarget() > (MaxDistance + GetTargetHitboxRadius()) then
             if not (PathfindInProgress() or PathIsRunning()) then
+                yield("/echo Unexpected Combat Move 2")
                 PathfindAndMoveTo(GetTargetRawXPos(), GetTargetRawYPos(), GetTargetRawZPos(), GetCharacterCondition(CharacterCondition.flying) and SelectedZone.flying)
             end
         else
@@ -2077,6 +2132,7 @@ function HandleUnexpectedCombat()
                 yield("/vnav stop")
             elseif not GetCharacterCondition(CharacterCondition.inCombat) then
                 --inch closer 3 seconds
+                yield("/echo Unexpected Combat Move 3")
                 PathfindAndMoveTo(GetTargetRawXPos(), GetTargetRawYPos(), GetTargetRawZPos(), GetCharacterCondition(CharacterCondition.flying) and SelectedZone.flying)
                 yield("/wait 3")
             end
@@ -2111,6 +2167,7 @@ function DoFate()
     then -- got pushed out of fate. go back
         yield("/vnav stop")
         yield("/wait 1")
+        LogInfo("[FATE] pushed out of fate going back!")
         PathfindAndMoveTo(CurrentFate.x, CurrentFate.y, CurrentFate.z, GetCharacterCondition(CharacterCondition.flying) and SelectedZone.flying)
         return
     elseif not IsFateActive(CurrentFate.fateId) or GetFateProgress(CurrentFate.fateId) == 100 then
@@ -2124,7 +2181,7 @@ function DoFate()
         else
             DidFate = true
             LogInfo("[FATE] No continuation for "..CurrentFate.fateName)
-            local randomWait = (math.floor(math.random() * (math.max(0, WaitUpTo - 3)) * 1000)/1000) + 3 -- truncated to 3 decimal places
+            local randomWait = (math.floor(math.random() * (math.max(0, MaxWait - 3)) * 1000)/1000) + MinWait -- truncated to 3 decimal places
             yield("/wait "..randomWait)
             TurnOffCombatMods()
             State = CharacterState.ready
@@ -2207,14 +2264,16 @@ function DoFate()
             if GetDistanceToTarget() <= (MaxDistance + GetTargetHitboxRadius()) then
                 if PathfindInProgress() or PathIsRunning() then
                     yield("/vnav stop")
-                    yield("/wait 5") -- wait 5s before inching any closer
-                elseif GetDistanceToTarget() > (1 + GetTargetHitboxRadius()) then -- never move into hitbox
+                    yield("/wait 5.002") -- wait 5s before inching any closer                           --Allison: If wait for casting, then should just check for casting
+                elseif (GetDistanceToTarget() > (1 + GetTargetHitboxRadius())) and not GetCharacterCondition(CharacterCondition.casting) then -- never move into hitbox
+                    yield("/echo Move 1")
                     PathfindAndMoveTo(x, y, z)
                     yield("/wait 1") -- inch closer by 1s
                 end
             elseif not (PathfindInProgress() or PathIsRunning()) then
-                yield("/wait 5") -- give 5s for casts to go off before attempting to move closer
-                if x ~= 0 and z~=0 and not GetCharacterCondition(CharacterCondition.inCombat) then
+                yield("/wait 5.003") -- give 5s for enemy AoE casts to go off before attempting to move closer
+                if (x ~= 0 and z~=0 and not GetCharacterCondition(CharacterCondition.inCombat)) and not GetCharacterCondition(CharacterCondition.casting) then
+                    yield("/echo Move 2")
                     PathfindAndMoveTo(x, y, z)
                 end
             end
@@ -2222,7 +2281,8 @@ function DoFate()
         else
             TargetClosestFateEnemy()
             yield("/wait 1") -- wait in case target doesn't stick
-            if not HasTarget() then
+            if (not HasTarget()) and not GetCharacterCondition(CharacterCondition.casting) then
+                yield("/echo Move 3")
                 PathfindAndMoveTo(CurrentFate.x, CurrentFate.y, CurrentFate.z)
             end
         end
@@ -2233,15 +2293,16 @@ function DoFate()
             end
         elseif not CurrentFate.isBossFate then
             if not (PathfindInProgress() or PathIsRunning()) then
-                yield("/wait 5")
+                yield("/wait 5.004")
                 local x,y,z = GetTargetRawXPos(), GetTargetRawYPos(), GetTargetRawZPos()
-                if x ~= 0 and z~=0 then
+                if (x ~= 0 and z~=0)  and not GetCharacterCondition(CharacterCondition.casting) then
+                    yield("/echo Move 4")
                     PathfindAndMoveTo(x,y,z, GetCharacterCondition(CharacterCondition.flying) and SelectedZone.flying)
                 end
             end
         end
     end
-        
+
     --hold buff thingy
     if GetFateProgress(CurrentFate.fateId) >= PercentageToHoldBuff then
         TurnOffRaidBuffs()
@@ -2269,7 +2330,7 @@ end
 function Ready()
     FoodCheck()
     PotionCheck()
-    
+
     CombatModsOn = false -- expect RSR to turn off after every fate
     GotCollectionsFullCredit = false
     ForlornMarked = false
@@ -2303,7 +2364,7 @@ function Ready()
     elseif not LogInfo("[FATE] Ready -> ExtractMateria") and ShouldExtractMateria and CanExtractMateria(100) and GetInventoryFreeSlotCount() > 1 then
         State = CharacterState.extractMateria
         LogInfo("[FATE] State Change: ExtractMateria")
-    elseif not LogInfo("[FATE] Ready -> WaitBonusBuff") and NextFate == nil and shouldWaitForBonusBuff then
+    elseif (not LogInfo("[FATE] Ready -> WaitBonusBuff") and NextFate == nil and shouldWaitForBonusBuff) and DownTimeWaitAtNearestAetheryte then
         if not HasTarget() or GetTargetName() ~= "aetheryte" or GetDistanceToTarget() > 20 then
             State = CharacterState.flyBackToAetheryte
             LogInfo("[FATE] State Change: FlyBackToAetheryte")
@@ -2344,7 +2405,7 @@ function Ready()
             else
                 LogInfo("[FATE] Waiting for fate rewards")
             end
-        elseif not HasTarget() or GetTargetName() ~= "aetheryte" or GetDistanceToTarget() > 20 then
+        elseif (not HasTarget() or GetTargetName() ~= "aetheryte" or GetDistanceToTarget()) and DownTimeWaitAtNearestAetheryte > 20 then
             State = CharacterState.flyBackToAetheryte
             LogInfo("[FATE] State Change: FlyBackToAetheryte")
         else

--- a/Fate Farming/Fate Farming.lua
+++ b/Fate Farming/Fate Farming.lua
@@ -128,13 +128,13 @@ IgnoreForlorns                      = false
 
 --Post Fate Settings
 MinWait                             = 3             --Min number of seconds it should wait until mounting up for next fate.
-MaxWait                             = 6             --Max number of seconds it should wait until mounting up for next fate.
+MaxWait                             = 10            --Max number of seconds it should wait until mounting up for next fate.
                                                         --Actual wait time will be a randomly generated number between MinWait and MaxWait.
 DownTimeWaitAtNearestAetheryte      = false         --When waiting for fates to pop, should you fly to the nearest Aetheryte and wait there?
 EnableChangeInstance                = true          --should it Change Instance when there is no Fate (only works on DT fates)
     WaitIfBonusBuff                 = true          --Don't change instances if you have the Twist of Fate bonus buff
     NumberOfInstances               = 2
-ShouldExchangeBicolorGemstones      = true         --Should it exchange Bicolor Gemstone Vouchers?
+ShouldExchangeBicolorGemstones      = true          --Should it exchange Bicolor Gemstone Vouchers?
     ItemToPurchase                  = "Turali Bicolor Gemstone Voucher"        -- Old Sharlayan for "Bicolor Gemstone Voucher" and Solution Nine for "Turali Bicolor Gemstone Voucher"
 SelfRepair                          = false         --if false, will go to Limsa mender
     RepairAmount                    = 20            --the amount it needs to drop before Repairing (set it to 0 if you don't want it to repair)
@@ -2109,7 +2109,6 @@ function HandleUnexpectedCombat()
 
     if GetCharacterCondition(CharacterCondition.mounted) then
         if not (PathfindInProgress() or PathIsRunning()) then
-            yield("/echo Unexpected Combat Move 1")
             PathfindAndMoveTo(GetPlayerRawXPos(), GetPlayerRawYPos() + 10, GetPlayerRawZPos(), true)
         end
         yield("/wait 10")
@@ -2125,7 +2124,6 @@ function HandleUnexpectedCombat()
     if HasTarget() then
         if GetDistanceToTarget() > (MaxDistance + GetTargetHitboxRadius()) then
             if not (PathfindInProgress() or PathIsRunning()) then
-                yield("/echo Unexpected Combat Move 2")
                 PathfindAndMoveTo(GetTargetRawXPos(), GetTargetRawYPos(), GetTargetRawZPos(), GetCharacterCondition(CharacterCondition.flying) and SelectedZone.flying)
             end
         else
@@ -2133,7 +2131,6 @@ function HandleUnexpectedCombat()
                 yield("/vnav stop")
             elseif not GetCharacterCondition(CharacterCondition.inCombat) then
                 --inch closer 3 seconds
-                yield("/echo Unexpected Combat Move 3")
                 PathfindAndMoveTo(GetTargetRawXPos(), GetTargetRawYPos(), GetTargetRawZPos(), GetCharacterCondition(CharacterCondition.flying) and SelectedZone.flying)
                 yield("/wait 3")
             end
@@ -2265,16 +2262,14 @@ function DoFate()
             if GetDistanceToTarget() <= (MaxDistance + GetTargetHitboxRadius()) then
                 if PathfindInProgress() or PathIsRunning() then
                     yield("/vnav stop")
-                    yield("/wait 5.002") -- wait 5s before inching any closer                           --Allison: If wait for casting, then should just check for casting
+                    yield("/wait 5.002") -- wait 5s before inching any closer
                 elseif (GetDistanceToTarget() > (1 + GetTargetHitboxRadius())) and not GetCharacterCondition(CharacterCondition.casting) then -- never move into hitbox
-                    yield("/echo Move 1")
                     PathfindAndMoveTo(x, y, z)
                     yield("/wait 1") -- inch closer by 1s
                 end
             elseif not (PathfindInProgress() or PathIsRunning()) then
                 yield("/wait 5.003") -- give 5s for enemy AoE casts to go off before attempting to move closer
                 if (x ~= 0 and z~=0 and not GetCharacterCondition(CharacterCondition.inCombat)) and not GetCharacterCondition(CharacterCondition.casting) then
-                    yield("/echo Move 2")
                     PathfindAndMoveTo(x, y, z)
                 end
             end
@@ -2283,7 +2278,6 @@ function DoFate()
             TargetClosestFateEnemy()
             yield("/wait 1") -- wait in case target doesn't stick
             if (not HasTarget()) and not GetCharacterCondition(CharacterCondition.casting) then
-                yield("/echo Move 3")
                 PathfindAndMoveTo(CurrentFate.x, CurrentFate.y, CurrentFate.z)
             end
         end
@@ -2297,7 +2291,6 @@ function DoFate()
                 yield("/wait 5.004")
                 local x,y,z = GetTargetRawXPos(), GetTargetRawYPos(), GetTargetRawZPos()
                 if (x ~= 0 and z~=0)  and not GetCharacterCondition(CharacterCondition.casting) then
-                    yield("/echo Move 4")
                     PathfindAndMoveTo(x,y,z, GetCharacterCondition(CharacterCondition.flying) and SelectedZone.flying)
                 end
             end


### PR DESCRIPTION
- Added priority for checking distance to FATE accounting for apossible lower distance if you teleported.
- Added FatePriority Setting. Default works the same as before but with new check from above. Progress -> Bonus -> Time Left -> Distance
- Added setting for if you should wait at the Aetheryte when no FATE is found. If you disable, you wait where the FATE finished.
- Added MinWait setting because sometimes 3 seconds felt to long.
  - Changed name of WaitUpTo to match MinWait.
- Added check to disable targeting with VBM if you are using RSRfor the rotation plugin.
- Small adjustment to wait time after choosing nextFate, resultsin landing further from center of fates upon approach.
- New extra checks in movement to prevent cast cancelling.
- May have messed something up when pushed out of the fate.
- Fixed typo with "should it to Turn" -> "should it do Turn"